### PR TITLE
Fix example in Readme for custom src setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module.exports = function (environment) {
           mode: 'hash',
           nonUniqueHostnames: 'checkout.stripe.com',
           pathOverwriter: 'myPathOverwriter',
-          src: 'my-custom-script.example.org/latest.js',
+          src: 'https://my-custom-script.example.org/latest.js',
         }
       }
     ]


### PR DESCRIPTION
Updates readme to show the proper way to use the src property in the config for SimpleAnalytics.

without the protocol it tries to append it to your base url like `https://example.com/sa.example.com/latest.js`